### PR TITLE
chore: update deps to fix build issue (prettier)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "verba-volant",
       "version": "1.0.0",
       "hasInstallScript": true,
-      "dependencies": {
-        "run-p": "0.0.0"
-      },
       "devDependencies": {
         "npm-run-all": "^4.1.5"
       }
@@ -187,9 +184,9 @@
       "dev": true
     },
     "node_modules/get-intrinsic": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
-      "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
       "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
@@ -544,11 +541,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/run-p": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/run-p/-/run-p-0.0.0.tgz",
-      "integrity": "sha1-cWpVvRICd6nZDaX4IzO3C5GAiPI="
-    },
     "node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -847,9 +839,9 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
-      "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.2.tgz",
+      "integrity": "sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
@@ -1102,11 +1094,6 @@
         "is-core-module": "^2.1.0",
         "path-parse": "^1.0.6"
       }
-    },
-    "run-p": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/run-p/-/run-p-0.0.0.tgz",
-      "integrity": "sha1-cWpVvRICd6nZDaX4IzO3C5GAiPI="
     },
     "semver": {
       "version": "5.7.1",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,5 @@
   },
   "devDependencies": {
     "npm-run-all": "^4.1.5"
-  },
-  "dependencies": {
-    "run-p": "0.0.0"
   }
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -30,6 +30,7 @@
         "eslint-plugin-prettier": "^3.2.0",
         "eslint-plugin-vue": "^7.2.0",
         "node-sass": "^5.0.0",
+        "prettier": "^2.2.1",
         "sass-loader": "^10.1.0",
         "vue-cli-plugin-i18n": "^1.0.1",
         "vue-template-compiler": "^2.6.12"
@@ -11708,7 +11709,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
       "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -26071,8 +26071,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
       "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-prettier": "^3.2.0",
     "eslint-plugin-vue": "^7.2.0",
     "node-sass": "^5.0.0",
+    "prettier": "^2.2.1",
     "sass-loader": "^10.1.0",
     "vue-cli-plugin-i18n": "^1.0.1",
     "vue-template-compiler": "^2.6.12"


### PR DESCRIPTION
Añade "prettier" a las devDependencies de la web. Es una [peer dependency de @vue/eslint-config-prettier](https://stackoverflow.com/a/58145938/12388) y sin ella da este error al hacer `npm run start`, siguiendo los pasos del README:

```
npm run start

> verba-volant@1.0.0 start /Users/guido/verba
> run-p start:api start:web

> verba-volant@1.0.0 start:api /Users/guido/verba
> npm run start --prefix api

> verba-volant@1.0.0 start:web /Users/guido//verba
> npm run start --prefix web

> verba-volant-api@1.0.0 start /Users/guido/verba/api
> nodemon --exec babel-node src/index.js

> verba-volant-web@1.0.0 start /Users/guido/verba/web
> vue-cli-service serve

[nodemon] 2.0.6
[nodemon] to restart at any time, enter `rs`
[nodemon] watching path(s): *.*
[nodemon] watching extensions: js,mjs,json
[nodemon] starting `babel-node src/index.js`
 INFO  Starting development server...
Server running on port 8888
98% after emitting CopyPlugin

 ERROR  Failed to compile with 1 error                                                                                                                                                                       12:25:38 PM

 error  in ./src/main.js

Syntax Error: Error: Cannot find module 'prettier'
Require stack:
- /Users/guido/verba/web/node_modules/eslint-plugin-prettier/eslint-plugin-prettier.js
- /Users/guido/verba/web/node_modules/eslint/lib/cli-engine/config-array-factory.js
- /Users/guido/verba/web/node_modules/eslint/lib/cli-engine/cascading-config-array-factory.js
[...]
```

Además elimino la dependencia `run-p` del `package.json` principal. Es un alias que instala `npm-run-all`, no es necesario indicar esa dependencia.