### PR TITLE
fix: visual glitch in csv download link

### DIFF
--- a/web/src/components/Results.vue
+++ b/web/src/components/Results.vue
@@ -19,8 +19,7 @@
               })
             "
           ></span>
-          (
-          <a href="#" @click="onDownloadClick()">CSV</a>)
+          (<a href="#" @click="onDownloadClick()">CSV</a>)
           <span v-if="results.length > 50" class="text-secondary">
             &nbsp;&mdash;&nbsp;
             {{


### PR DESCRIPTION
Elimina un espacio para solucionar el pequeño _"glitch"_ visual que no me dejaba dormir en la descarga CSV.

![Screenshot 2020-12-26 at 12 33 16](https://user-images.githubusercontent.com/673420/103151092-332bf380-477b-11eb-9fca-31a476cbf599.png)
